### PR TITLE
Fix function name in example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ range of people. Implemented contrast ratio rules follow [the WCAG 2.1 standard]
 Check an entire theme data your app uses:
 
 ```dart
-testTheme(
+themeTest(
   'Theme accessibility test',
   themeData,
   accessibilityLevel: ThemeAccessibilityLevel.normal,

--- a/example/EXAMPLE.md
+++ b/example/EXAMPLE.md
@@ -3,7 +3,7 @@ Example usage of `accessibility_test`.
 ## Theme test
 
 ```dart
-testTheme(
+themeTest(
   'Theme accessibility test',
   themeData,
   accessibilityLevel: ThemeAccessibilityLevel.normal,


### PR DESCRIPTION
`testTheme` → `themeTest`